### PR TITLE
Add 30-day trial system scaffolding with feature gating and conversion services

### DIFF
--- a/lib/core/models/subscription_plan_model.dart
+++ b/lib/core/models/subscription_plan_model.dart
@@ -1,0 +1,33 @@
+class SubscriptionPlan {
+  final String? id;
+  final String name;
+  final double? priceMonthly;
+  final Map<String, dynamic> features;
+  const SubscriptionPlan({this.id, required this.name, this.priceMonthly, this.features = const {}});
+  factory SubscriptionPlan.fromJson(Map<String, dynamic> json) {
+    return SubscriptionPlan(
+      id: json['id']?.toString(),
+      name: json['name'] ?? '',
+      priceMonthly: json['price_monthly'] == null ? null : (json['price_monthly'] as num).toDouble(),
+      features: Map<String, dynamic>.from(json['features'] ?? {}),
+    );
+  }
+  Map<String, dynamic> toJson() {
+    return {
+      if (id != null) 'id': id,
+      'name': name,
+      'price_monthly': priceMonthly,
+      'features': features,
+    };
+  }
+  bool get isPremium => name.toLowerCase() == 'premium';
+  bool get isFree => name.toLowerCase() == 'free';
+  int featureInt(String key, {int defaultValue = 0}) {
+    final v = features[key];
+    if (v == null) return defaultValue;
+    if (v is int) return v;
+    if (v is double) return v.toInt();
+    if (v is String) return int.tryParse(v) ?? defaultValue;
+    return defaultValue;
+  }
+}

--- a/lib/core/models/trial_status_model.dart
+++ b/lib/core/models/trial_status_model.dart
@@ -1,0 +1,43 @@
+class TrialStatus {
+  final DateTime? trialStartDate;
+  final DateTime? trialEndDate;
+  final String subscriptionStatus;
+  const TrialStatus({required this.trialStartDate, required this.trialEndDate, required this.subscriptionStatus});
+  factory TrialStatus.fromJson(Map<String, dynamic> json) {
+    return TrialStatus(
+      trialStartDate: json['trial_start_date'] != null ? DateTime.tryParse(json['trial_start_date'].toString()) : null,
+      trialEndDate: json['trial_end_date'] != null ? DateTime.tryParse(json['trial_end_date'].toString()) : null,
+      subscriptionStatus: (json['subscription_status'] ?? 'trial').toString(),
+    );
+  }
+  Map<String, dynamic> toJson() {
+    return {
+      'trial_start_date': trialStartDate?.toIso8601String(),
+      'trial_end_date': trialEndDate?.toIso8601String(),
+      'subscription_status': subscriptionStatus,
+    };
+  }
+  bool get isInTrialPeriod {
+    if (subscriptionStatus == 'premium') return false;
+    if (trialStartDate == null || trialEndDate == null) return false;
+    final now = DateTime.now().toUtc();
+    return now.isAfter(trialStartDate!.toUtc()) && now.isBefore(trialEndDate!.toUtc());
+  }
+  int get remainingTrialDays {
+    if (trialEndDate == null) return 0;
+    final now = DateTime.now().toUtc();
+    final diff = trialEndDate!.toUtc().difference(now).inDays;
+    return diff > 0 ? diff : 0;
+  }
+  int get daysIntoTrial {
+    if (trialStartDate == null) return 0;
+    final now = DateTime.now().toUtc();
+    final diff = now.difference(trialStartDate!.toUtc()).inDays;
+    return diff > 0 ? diff : 0;
+  }
+  bool get isExpired {
+    if (subscriptionStatus == 'premium') return false;
+    if (trialEndDate == null) return true;
+    return DateTime.now().toUtc().isAfter(trialEndDate!.toUtc());
+  }
+}

--- a/lib/core/models/user_profile_model.dart
+++ b/lib/core/models/user_profile_model.dart
@@ -1,0 +1,56 @@
+class UserProfile {
+  final String id;
+  final String? familyId;
+  final bool isFamilyCreator;
+  final DateTime? trialStartDate;
+  final DateTime? trialEndDate;
+  final String subscriptionStatus;
+  final Map<String, dynamic> featureUsageTracking;
+  final int storageUsedBytes;
+  final int voiceTranscriptionMinutesThisMonth;
+  final int storyRecordingsThisMonth;
+  final int emergencyContactsCount;
+  const UserProfile({
+    required this.id,
+    this.familyId,
+    this.isFamilyCreator = false,
+    this.trialStartDate,
+    this.trialEndDate,
+    this.subscriptionStatus = 'trial',
+    this.featureUsageTracking = const {},
+    this.storageUsedBytes = 0,
+    this.voiceTranscriptionMinutesThisMonth = 0,
+    this.storyRecordingsThisMonth = 0,
+    this.emergencyContactsCount = 0,
+  });
+  factory UserProfile.fromJson(Map<String, dynamic> json) {
+    return UserProfile(
+      id: json['id']?.toString() ?? '',
+      familyId: json['family_id']?.toString(),
+      isFamilyCreator: json['is_family_creator'] == true,
+      trialStartDate: json['trial_start_date'] != null ? DateTime.tryParse(json['trial_start_date'].toString()) : null,
+      trialEndDate: json['trial_end_date'] != null ? DateTime.tryParse(json['trial_end_date'].toString()) : null,
+      subscriptionStatus: (json['subscription_status'] ?? 'trial').toString(),
+      featureUsageTracking: Map<String, dynamic>.from(json['feature_usage_tracking'] ?? {}),
+      storageUsedBytes: (json['storage_used_bytes'] ?? 0) is int ? json['storage_used_bytes'] : int.tryParse(json['storage_used_bytes']?.toString() ?? '0') ?? 0,
+      voiceTranscriptionMinutesThisMonth: (json['voice_minutes_month'] ?? 0) is int ? json['voice_minutes_month'] : int.tryParse(json['voice_minutes_month']?.toString() ?? '0') ?? 0,
+      storyRecordingsThisMonth: (json['story_recordings_month'] ?? 0) is int ? json['story_recordings_month'] : int.tryParse(json['story_recordings_month']?.toString() ?? '0') ?? 0,
+      emergencyContactsCount: (json['emergency_contacts_count'] ?? 0) is int ? json['emergency_contacts_count'] : int.tryParse(json['emergency_contacts_count']?.toString() ?? '0') ?? 0,
+    );
+  }
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'family_id': familyId,
+      'is_family_creator': isFamilyCreator,
+      'trial_start_date': trialStartDate?.toIso8601String(),
+      'trial_end_date': trialEndDate?.toIso8601String(),
+      'subscription_status': subscriptionStatus,
+      'feature_usage_tracking': featureUsageTracking,
+      'storage_used_bytes': storageUsedBytes,
+      'voice_minutes_month': voiceTranscriptionMinutesThisMonth,
+      'story_recordings_month': storyRecordingsThisMonth,
+      'emergency_contacts_count': emergencyContactsCount,
+    };
+  }
+}

--- a/lib/core/services/conversion_optimization_service.dart
+++ b/lib/core/services/conversion_optimization_service.dart
@@ -1,0 +1,29 @@
+import '../models/user_profile_model.dart';
+import 'trial_service.dart';
+import 'trial_analytics_service.dart';
+
+class ConversionOptimizationService {
+  final TrialService trialService;
+  final TrialAnalyticsService analyticsService;
+  ConversionOptimizationService({required this.trialService, required this.analyticsService});
+  bool shouldPromptUpgrade(String featureKey, UserProfile user, {Map<String, dynamic>? contextData}) {
+    if (user.subscriptionStatus == 'premium') return false;
+    if (trialService.isInTrialPeriod(user)) return false;
+    if (featureKey == 'media_storage') return true;
+    if (featureKey == 'advanced_health_analytics') return true;
+    if (featureKey == 'emergency_contacts_exceeded') return true;
+    if (featureKey == 'story_recordings') return true;
+    if (featureKey == 'family_archive_export') return true;
+    return false;
+  }
+  String getUpgradeMessage(UserProfile user, String featureKey) {
+    final msg = analyticsService.getPersonalizedUpgradeMessage(user);
+    if (msg.isNotEmpty) return msg;
+    if (featureKey == 'media_storage') return 'Keep your family memories safe with unlimited storage.';
+    if (featureKey == 'advanced_health_analytics') return 'Unlock advanced health analytics for deeper insights.';
+    if (featureKey == 'emergency_contacts_exceeded') return 'Add unlimited emergency contacts for peace of mind.';
+    if (featureKey == 'story_recordings') return 'Record unlimited stories from your loved ones.';
+    if (featureKey == 'family_archive_export') return 'Export and preserve your entire family archive.';
+    return 'Upgrade to continue enjoying premium features.';
+  }
+}

--- a/lib/core/services/feature_gate_service.dart
+++ b/lib/core/services/feature_gate_service.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import '../models/user_profile_model.dart';
+import 'trial_service.dart';
+
+class FeatureGateService {
+  final TrialService trialService;
+  FeatureGateService(this.trialService);
+  bool canUploadMedia(UserProfile user, int fileSizeBytes) {
+    if (trialService.isInTrialPeriod(user)) return true;
+    if (user.subscriptionStatus == 'premium') return true;
+    const gb = 1024 * 1024 * 1024;
+    final limit = 1 * gb;
+    return user.storageUsedBytes + fileSizeBytes <= limit;
+  }
+  bool canUseVoiceTranscription(UserProfile user) {
+    if (trialService.isInTrialPeriod(user)) return true;
+    if (user.subscriptionStatus == 'premium') return true;
+    return user.voiceTranscriptionMinutesThisMonth < 60;
+  }
+  bool canRecordStory(UserProfile user) {
+    if (trialService.isInTrialPeriod(user)) return true;
+    if (user.subscriptionStatus == 'premium') return true;
+    return user.storyRecordingsThisMonth < 3;
+  }
+  Widget buildUpgradePrompt(String featureKey, BuildContext context) {
+    String title = 'Upgrade required';
+    String message = 'This feature requires a premium subscription.';
+    if (featureKey == 'media_storage') {
+      title = 'Storage limit reached';
+      message = 'Upgrade to continue uploading unlimited photos and videos.';
+    } else if (featureKey == 'voice_transcription') {
+      title = 'Voice minutes limit reached';
+      message = 'Upgrade for unlimited voice transcription minutes.';
+    } else if (featureKey == 'story_recordings') {
+      title = 'Recording limit reached';
+      message = 'Upgrade for unlimited story recordings.';
+    } else if (featureKey == 'advanced_health_analytics') {
+      title = 'Premium analytics';
+      message = 'Upgrade to access advanced health analytics.';
+    } else if (featureKey == 'professional_reports') {
+      title = 'Premium reports';
+      message = 'Upgrade to generate professional reports.';
+    } else if (featureKey == 'message_history') {
+      title = 'Message history limit';
+      message = 'Upgrade for unlimited message history.';
+    } else if (featureKey == 'family_archive_export') {
+      title = 'Export memories';
+      message = 'Upgrade to export your full family archive.';
+    }
+    return AlertDialog(
+      title: Text(title),
+      content: Text(message),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: const Text('Not now'),
+        ),
+        ElevatedButton(
+          onPressed: () => Navigator.of(context).pop('upgrade'),
+          child: const Text('Upgrade'),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/core/services/trial_analytics_service.dart
+++ b/lib/core/services/trial_analytics_service.dart
@@ -1,0 +1,57 @@
+import 'dart:math';
+import '../models/user_profile_model.dart';
+
+class TrialAnalyticsService {
+  final Map<String, Duration> _featureTime = {};
+  void trackFeatureEngagement(String feature, Duration timeSpent) {
+    final current = _featureTime[feature] ?? Duration.zero;
+    _featureTime[feature] = current + timeSpent;
+  }
+  double calculateConversionProbability(UserProfile user) {
+    double score = 0;
+    final t = user.featureUsageTracking;
+    void addScore(String k, double w) {
+      final m = t[k];
+      if (m is Map && (m['count'] ?? 0) is int) {
+        final c = m['count'] as int;
+        score += min(c * w, w * 5);
+      }
+    }
+    addScore('media_storage', 0.25);
+    addScore('voice_transcription', 0.15);
+    addScore('story_recordings', 0.25);
+    addScore('advanced_health_analytics', 0.2);
+    addScore('message_history', 0.1);
+    final totalMinutes = _featureTime.values.fold<int>(0, (a, b) => a + b.inMinutes);
+    score += min(totalMinutes / 120.0, 0.3);
+    if (user.subscriptionStatus == 'trial' && user.trialEndDate != null) {
+      final daysLeft = user.trialEndDate!.difference(DateTime.now()).inDays;
+      if (daysLeft <= 5) score += 0.2;
+    }
+    if (score < 0) score = 0;
+    if (score > 1) score = 1;
+    return score;
+  }
+  String getPersonalizedUpgradeMessage(UserProfile user) {
+    final t = user.featureUsageTracking;
+    String topFeature = '';
+    int topCount = 0;
+    for (final e in t.entries) {
+      final m = e.value;
+      if (m is Map && (m['count'] ?? 0) is int) {
+        final c = m['count'] as int;
+        if (c > topCount) {
+          topCount = c;
+          topFeature = e.key;
+        }
+      }
+    }
+    if (topFeature.isEmpty) return '';
+    if (topFeature == 'media_storage') return 'Upgrade for unlimited photo and video storage.';
+    if (topFeature == 'story_recordings') return 'Upgrade to record unlimited family stories.';
+    if (topFeature == 'voice_transcription') return 'Upgrade for unlimited voice transcription minutes.';
+    if (topFeature == 'advanced_health_analytics') return 'Upgrade to unlock advanced health analytics.';
+    if (topFeature == 'message_history') return 'Upgrade to view your full message history.';
+    return '';
+  }
+}

--- a/lib/core/services/trial_service.dart
+++ b/lib/core/services/trial_service.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import '../models/user_profile_model.dart';
+
+abstract class CacheStore {
+  Future<void> setString(String key, String value);
+  Future<String?> getString(String key);
+}
+
+class MemoryCacheStore implements CacheStore {
+  final Map<String, String> _store = {};
+  @override
+  Future<void> setString(String key, String value) async {
+    _store[key] = value;
+  }
+  @override
+  Future<String?> getString(String key) async {
+    return _store[key];
+  }
+}
+
+abstract class PaymentGateway {
+  Future<bool> startCheckout({required String userId, required String planName});
+}
+
+class TrialService {
+  final dynamic supabase;
+  final CacheStore cache;
+  final PaymentGateway? paymentGateway;
+  TrialService({this.supabase, CacheStore? cache, this.paymentGateway}) : cache = cache ?? MemoryCacheStore();
+  bool isInTrialPeriod(UserProfile user) {
+    if (user.subscriptionStatus == 'premium') return false;
+    if (user.trialEndDate == null) return false;
+    final now = DateTime.now().toUtc();
+    return now.isBefore(user.trialEndDate!.toUtc());
+  }
+  int getRemainingTrialDays(UserProfile user) {
+    if (user.trialEndDate == null) return 0;
+    final now = DateTime.now().toUtc();
+    final diff = user.trialEndDate!.toUtc().difference(now).inDays;
+    return diff > 0 ? diff : 0;
+  }
+  bool isFeatureAvailable(String featureKey, UserProfile user) {
+    if (isInTrialPeriod(user)) return true;
+    if (user.subscriptionStatus == 'premium') return true;
+    const premiumOnly = {
+      'advanced_health_analytics',
+      'professional_reports',
+      'family_archive_export',
+    };
+    if (premiumOnly.contains(featureKey)) return false;
+    return true;
+  }
+  Future<void> trackFeatureUsage(String featureKey, UserProfile user) async {
+    final key = 'feature_usage_${user.id}';
+    final now = DateTime.now().toIso8601String();
+    final tracking = Map<String, dynamic>.from(user.featureUsageTracking);
+    final f = Map<String, dynamic>.from(tracking[featureKey] ?? {});
+    final c = (f['count'] ?? 0) is int ? f['count'] : int.tryParse(f['count']?.toString() ?? '0') ?? 0;
+    f['count'] = c + 1;
+    f['last_used_at'] = now;
+    tracking[featureKey] = f;
+    final cached = jsonEncode(tracking);
+    await cache.setString(key, cached);
+    try {
+      if (supabase != null) {
+        await supabase.from('user_profiles').update({'feature_usage_tracking': tracking}).eq('id', user.id);
+      }
+    } catch (e) {
+      if (kDebugMode) {}
+    }
+  }
+  Future<bool> convertTrialToPremium(UserProfile user) async {
+    bool paid = true;
+    if (paymentGateway != null) {
+      paid = await paymentGateway!.startCheckout(userId: user.id, planName: 'premium');
+    }
+    if (!paid) return false;
+    try {
+      if (supabase != null) {
+        await supabase.from('user_profiles').update({'subscription_status': 'premium'}).eq('id', user.id);
+      }
+    } catch (e) {
+      if (kDebugMode) {}
+      return false;
+    }
+    return true;
+  }
+  Map<String, dynamic> getTrialUsageAnalytics(UserProfile user) {
+    final tracking = Map<String, dynamic>.from(user.featureUsageTracking);
+    final result = <String, dynamic>{};
+    for (final entry in tracking.entries) {
+      final v = Map<String, dynamic>.from(entry.value is Map ? entry.value : {});
+      result[entry.key] = {
+        'count': v['count'] ?? 0,
+        'last_used_at': v['last_used_at'],
+      };
+    }
+    result['remaining_trial_days'] = getRemainingTrialDays(user);
+    result['in_trial'] = isInTrialPeriod(user);
+    return result;
+  }
+}

--- a/lib/features/trial_management/providers/trial_status_provider.dart
+++ b/lib/features/trial_management/providers/trial_status_provider.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/foundation.dart';
+import '../../../core/models/user_profile_model.dart';
+import '../../../core/services/trial_service.dart';
+import '../../../core/services/feature_gate_service.dart';
+import '../../../core/services/conversion_optimization_service.dart';
+import '../../../core/services/trial_analytics_service.dart';
+
+class TrialStatusProvider extends ChangeNotifier {
+  final TrialService trialService;
+  final FeatureGateService featureGateService;
+  final ConversionOptimizationService conversionService;
+  final TrialAnalyticsService analyticsService;
+  UserProfile? _user;
+  TrialStatusProvider({required this.trialService, required this.featureGateService, required this.conversionService, required this.analyticsService});
+  void setUser(UserProfile user) {
+    _user = user;
+    notifyListeners();
+  }
+  UserProfile? get user => _user;
+  bool get isInTrial => _user != null && trialService.isInTrialPeriod(_user!);
+  int get remainingDays => _user == null ? 0 : trialService.getRemainingTrialDays(_user!);
+  Map<String, dynamic> get usage => _user?.featureUsageTracking ?? {};
+  Future<void> trackUsage(String featureKey) async {
+    if (_user == null) return;
+    await trialService.trackFeatureUsage(featureKey, _user!);
+    final m = Map<String, dynamic>.from(_user!.featureUsageTracking);
+    final f = Map<String, dynamic>.from(m[featureKey] ?? {});
+    final c = (f['count'] ?? 0) is int ? f['count'] : int.tryParse(f['count']?.toString() ?? '0') ?? 0;
+    f['count'] = c + 1;
+    f['last_used_at'] = DateTime.now().toIso8601String();
+    m[featureKey] = f;
+    _user = UserProfile(
+      id: _user!.id,
+      familyId: _user!.familyId,
+      isFamilyCreator: _user!.isFamilyCreator,
+      trialStartDate: _user!.trialStartDate,
+      trialEndDate: _user!.trialEndDate,
+      subscriptionStatus: _user!.subscriptionStatus,
+      featureUsageTracking: m,
+      storageUsedBytes: _user!.storageUsedBytes,
+      voiceTranscriptionMinutesThisMonth: _user!.voiceTranscriptionMinutesThisMonth,
+      storyRecordingsThisMonth: _user!.storyRecordingsThisMonth,
+      emergencyContactsCount: _user!.emergencyContactsCount,
+    );
+    notifyListeners();
+  }
+  bool canUploadMedia(int fileSizeBytes) {
+    if (_user == null) return false;
+    return featureGateService.canUploadMedia(_user!, fileSizeBytes);
+  }
+  bool canUseVoiceTranscription() {
+    if (_user == null) return false;
+    return featureGateService.canUseVoiceTranscription(_user!);
+  }
+  bool canRecordStory() {
+    if (_user == null) return false;
+    return featureGateService.canRecordStory(_user!);
+  }
+  bool shouldPromptUpgrade(String featureKey, {Map<String, dynamic>? contextData}) {
+    if (_user == null) return false;
+    return conversionService.shouldPromptUpgrade(featureKey, _user!, contextData: contextData);
+  }
+  String upgradeMessage(String featureKey) {
+    if (_user == null) return '';
+    return conversionService.getUpgradeMessage(_user!, featureKey);
+  }
+  void trackEngagement(String feature, Duration timeSpent) {
+    analyticsService.trackFeatureEngagement(feature, timeSpent);
+    notifyListeners();
+  }
+  double get conversionProbability => _user == null ? 0 : analyticsService.calculateConversionProbability(_user!);
+  Future<bool> upgradeToPremium() async {
+    if (_user == null) return false;
+    final ok = await trialService.convertTrialToPremium(_user!);
+    if (!ok) return false;
+    _user = UserProfile(
+      id: _user!.id,
+      familyId: _user!.familyId,
+      isFamilyCreator: _user!.isFamilyCreator,
+      trialStartDate: _user!.trialStartDate,
+      trialEndDate: _user!.trialEndDate,
+      subscriptionStatus: 'premium',
+      featureUsageTracking: _user!.featureUsageTracking,
+      storageUsedBytes: _user!.storageUsedBytes,
+      voiceTranscriptionMinutesThisMonth: _user!.voiceTranscriptionMinutesThisMonth,
+      storyRecordingsThisMonth: _user!.storyRecordingsThisMonth,
+      emergencyContactsCount: _user!.emergencyContactsCount,
+    );
+    notifyListeners();
+    return true;
+  }
+}

--- a/lib/features/trial_management/widgets/trial_countdown_widget.dart
+++ b/lib/features/trial_management/widgets/trial_countdown_widget.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/trial_status_provider.dart';
+
+class TrialCountdownWidget extends StatelessWidget {
+  final VoidCallback? onUpgrade;
+  const TrialCountdownWidget({super.key, this.onUpgrade});
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<TrialStatusProvider>(builder: (context, p, _) {
+      final inTrial = p.isInTrial;
+      final days = p.remainingDays;
+      if (!inTrial && days == 0 && p.user != null && p.user!.subscriptionStatus != 'premium') {
+        return Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const Text('Your trial has ended', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+                const SizedBox(height: 8),
+                const Text('Upgrade to keep using premium features for your family.'),
+                const SizedBox(height: 12),
+                ElevatedButton(
+                  onPressed: onUpgrade ?? p.upgradeToPremium,
+                  child: const Text('Upgrade to Premium'),
+                )
+              ],
+            ),
+          ),
+        );
+      }
+      final total = 30.0;
+      final remaining = days.toDouble();
+      final elapsed = (total - remaining).clamp(0, total);
+      String subtitle = 'Enjoy full access to all features.';
+      if (days <= 15 && days > 7) subtitle = 'Your trial is halfway through.';
+      if (days <= 7 && days > 0) subtitle = 'Your trial is ending soon.';
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(inTrial ? 'Trial: $days days left' : 'Trial status', style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              Text(subtitle),
+              const SizedBox(height: 12),
+              LinearProgressIndicator(value: elapsed / total),
+            ],
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/lib/features/trial_management/widgets/upgrade_prompt_widget.dart
+++ b/lib/features/trial_management/widgets/upgrade_prompt_widget.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/trial_status_provider.dart';
+
+class UpgradePromptWidget extends StatelessWidget {
+  final String featureKey;
+  final VoidCallback? onUpgrade;
+  const UpgradePromptWidget({super.key, required this.featureKey, this.onUpgrade});
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<TrialStatusProvider>(builder: (context, p, _) {
+      final message = p.upgradeMessage(featureKey);
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text('Go Premium', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              Text(message.isEmpty ? 'Upgrade to continue with this feature.' : message),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: ElevatedButton(
+                      onPressed: onUpgrade ?? p.upgradeToPremium,
+                      child: const Text('Upgrade for \$9.99/month'),
+                    ),
+                  ),
+                ],
+              )
+            ],
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/lib/features/trial_management/widgets/usage_stats_widget.dart
+++ b/lib/features/trial_management/widgets/usage_stats_widget.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/trial_status_provider.dart';
+
+class UsageStatsWidget extends StatelessWidget {
+  const UsageStatsWidget({super.key});
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<TrialStatusProvider>(builder: (context, p, _) {
+      final usage = p.usage;
+      final items = usage.entries.map((e) {
+        final v = e.value is Map ? e.value as Map : {};
+        final c = v['count'] ?? 0;
+        return MapEntry(e.key.toString(), c);
+      }).toList()
+        ..sort((a, b) => (b.value as int).compareTo(a.value as int));
+      return Card(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const Text('Your usage', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              if (items.isEmpty) const Text('Start exploring premium features during your trial.'),
+              for (final it in items.take(5))
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 4),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(it.key.replaceAll('_', ' ')),
+                      Text(it.value.toString()),
+                    ],
+                  ),
+                ),
+            ],
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/supabase/migrations/20250921_trial_system.sql
+++ b/supabase/migrations/20250921_trial_system.sql
@@ -1,0 +1,19 @@
+-- Add trial fields to user_profiles
+ALTER TABLE user_profiles ADD COLUMN trial_start_date TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE user_profiles ADD COLUMN trial_end_date TIMESTAMPTZ DEFAULT (NOW() + INTERVAL '30 days');
+ALTER TABLE user_profiles ADD COLUMN subscription_status TEXT DEFAULT 'trial';
+ALTER TABLE user_profiles ADD COLUMN feature_usage_tracking JSONB DEFAULT '{}';
+
+-- Create subscription_plans table
+CREATE TABLE subscription_plans (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  price_monthly DECIMAL(10,2),
+  features JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Insert basic plans
+INSERT INTO subscription_plans (name, price_monthly, features) VALUES 
+('free', 0.00, '{"media_storage_gb": 1, "emergency_contacts": 3, "story_recordings_per_month": 3, "voice_transcription_minutes": 60}'),
+('premium', 9.99, '{"media_storage_gb": -1, "emergency_contacts": -1, "story_recordings_per_month": -1, "voice_transcription_minutes": -1}');


### PR DESCRIPTION
Implements a 30-day free trial system with feature gating and conversion scaffolding.

Changes:
- Adds Supabase migration for trial fields and subscription plans
- Introduces core models for trial status and subscription plans
- Implements TrialService, FeatureGateService, ConversionOptimizationService, and TrialAnalyticsService
- Adds TrialStatusProvider for state management using Provider pattern
- Provides trial UI widgets: countdown, usage stats, and upgrade prompts

Type: Feature
Impact: Establishes the foundation for trials, gating, and upgrade flow across the app. Non-breaking; integrates as modular services and widgets.

Summary:
- Enable full-access 30-day trials and family-wide conversion strategy
- Gate high-value features post-trial with targeted upgrade prompts
- Track usage analytics to personalize messaging and improve conversion

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Capy](https://capy.ai) ([view task](https://capy.ai/project/28ebf8b7-cbe5-44e2-96d2-3a092c2e3aa1/task/5be1ee80-a0bb-4132-b6c8-b5b68eabfcb8))