### PR TITLE
Scope analyzers per subproject; reduce VS Code Problems noise

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+lib/**
+android/**
+ios/**
+supabase/**
+caregiver-dashboard/**

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "env": { "es2022": true, "node": true },
-  "extends": ["eslint:recommended"],
-  "parserOptions": { "ecmaVersion": 2022, "sourceType": "module" },
-  "rules": { "no-console": "off" }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -352,3 +352,6 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 
+
+# Allow tracking workspace settings for analyzer scoping
+!.vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,29 @@
+// Monorepo workspace-scoped analyzer settings to prevent cross-project linting/indexing.
+// Root ESLint lints only JS at root (scripts, web service worker). Caregiver dashboard and Flutter are isolated.
+{
+  "eslint.workingDirectories": [
+    { "directory": "./", "changeProcessCWD": true },
+    { "directory": "./caregiver-dashboard", "changeProcessCWD": true }
+  ],
+  "dart.analysisExcludedFolders": [
+    "${workspaceFolder}/caregiver-dashboard",
+    "${workspaceFolder}/security",
+    "${workspaceFolder}/supabase"
+  ],
+  "files.watcherExclude": {
+    "**/node_modules": true,
+    "**/.dart_tool": true,
+    "**/build": true,
+    "**/dist": true,
+    "**/.next": true,
+    "**/.expo": true
+  },
+  "search.exclude": {
+    "**/node_modules": true,
+    "**/.dart_tool": true,
+    "**/build": true,
+    "**/dist": true,
+    "**/.next": true,
+    "**/.expo": true
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,30 @@
+/*
+ Monorepo root ESLint flat config.
+ Scopes analyzers per subproject to avoid cross-project linting noise.
+ Ignored: Flutter (lib, android, ios), Supabase (Deno), and caregiver-dashboard (has its own ESLint).
+*/
+
+export default [
+  {
+    ignores: [
+      "lib/**",
+      "android/**",
+      "ios/**",
+      "supabase/**",
+      "caregiver-dashboard/**",
+    ],
+  },
+  {
+    files: [
+      "scripts/**/*.js",
+      "web/firebase-messaging-sw.js",
+    ],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: "module",
+    },
+    rules: {
+      "no-console": "off",
+    },
+  },
+];

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://deno.land/x/deno/cli/schemas/config-file.v1.json",
+  "fmt": { "indentWidth": 2, "lineWidth": 100 },
+  "lint": { "rules": { "tags": ["recommended"] } }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,6 @@
     "types": ["node"],
     "baseUrl": "."
   },
-  "include": ["security/src", "scripts"]
+  "include": ["security/src", "scripts"],
+  "exclude": ["supabase/**", "caregiver-dashboard/**", "lib/**", "android/**", "ios/**"]
 }


### PR DESCRIPTION
This PR scopes ESLint, TS, and Dart analyzers to their correct subprojects and prevents cross-project linting/indexing. See previous commit for full summary.